### PR TITLE
Add Applicative instance for Accessor, Mutator

### DIFF
--- a/src/Control/Lens/Getter.hs
+++ b/src/Control/Lens/Getter.hs
@@ -1,33 +1,62 @@
 {-# LANGUAGE DeriveFunctor, RankNTypes #-}
 module Control.Lens.Getter where
 import Control.Monad.State.Class
+import Control.Monad.Reader.Class
+import Control.Applicative
 import Unsafe.Coerce
+import Data.Monoid
+import Data.Foldable
+
 infixl 8 ^.
 
 type Getting r s a = (a -> Accessor r a) -> s -> Accessor r s
 type Getter s a = forall r. Getting r s a
 
+folded :: (Foldable f, Monoid r) => Getting r (f a) a
+folded ar = unsafeCoerce `asTypeOf` (Accessor .)
+  $ foldMap (unsafeCoerce `asTypeOf` (runAccessor .) $ ar)
+
+views :: MonadReader s m => Getting r s a -> (a -> r) -> m r
+views = asks unsafeCoerce
+{-# INLINE views #-}
+
+view :: MonadReader s m => Getting a s a -> m a
+view l = views l id
+{-# INLINE view #-}
 
 foldMapOf :: Getting r s a -> (a -> r) -> s -> r
-foldMapOf l r = runAccessor . l (Accessor . r)
+foldMapOf = unsafeCoerce
+{-# INLINE foldMapOf #-}
 
-foldOf :: Getter s a -> s -> a
-foldOf l v = foldMapOf l id v
+foldOf :: Getting a s a -> s -> a
+foldOf l = foldMapOf l id
+{-# INLINE foldOf #-}
 
-to :: (s -> a) -> Getting r s a
-to f g = unsafeCoerce . g . f
+to :: (s -> a) -> Getter s a
+to f = \ar -> unsafeCoerce (ar . f)
+{-# INLINE to #-}
 
+(^.) :: s -> Getting a s a -> a
 (^.) = flip foldOf
+{-# INLINE (^.) #-}
 
 ----
 
+uses :: MonadState s m => Getter s a -> (a -> r) -> m r
+uses g f = get >>= foldMapOf g (return . f)
+{-# INLINE uses #-}
+
 use :: MonadState s m => Getter s a -> m a
-use g = do
-  state <- get
-  return $ state^.g
+use g = uses g id
+{-# INLINE use #-}
 
 ----
 
 newtype Accessor r a = Accessor { runAccessor :: r }
   deriving (Show, Read, Eq, Ord, Functor)
 
+instance Monoid r => Applicative (Accessor r) where
+  pure _ = Accessor mempty
+  {-# INLINE pure #-}
+  Accessor a <*> Accessor b = Accessor (mappend a b)
+  {-# INLINE (<*>) #-}

--- a/src/Control/Lens/Lens.hs
+++ b/src/Control/Lens/Lens.hs
@@ -1,5 +1,5 @@
 {-# LANGUAGE RankNTypes #-}
-module Control.Lens.Lens 
+module Control.Lens.Lens
   ( module Control.Lens.Getter
   , module Control.Lens.Setter
   , Lens(..)

--- a/src/Control/Lens/Setter.hs
+++ b/src/Control/Lens/Setter.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE DeriveFunctor #-}
 module Control.Lens.Setter where
 import Control.Monad.State.Class
+import Control.Applicative
+import Unsafe.Coerce
 
 infixl 4 .=, %=, +=, -=, *=, //=
 infixr 4 .~, %~, +~, -~, *~, /~
@@ -9,55 +11,75 @@ infixl 1 &
 type Setter s t a b = (a -> Mutator b) -> s -> Mutator t
 
 over :: Setter s t a b -> (a -> b) -> s -> t
-over l f = runMutator . l (Mutator . f)
+over = unsafeCoerce
+{-# INLINE over #-}
 
 set :: Setter s t a b -> b -> s -> t
 set a v = over a $ const v
+{-# INLINE set #-}
 
+(.~) :: Setter s t a b -> b -> s -> t
 (.~) = set
+{-# INLINE (.~) #-}
+
 (&) = flip ($)
+{-# INLINE (&) #-}
 
 ----
 
 (%~) :: Setter s t a b -> (a -> b) -> s -> t
 (%~) = over
+{-# INLINE (%~) #-}
 
 (+~) :: Num a => Setter s t a a -> a -> s -> t
 s +~ x = over s (+ x)
+{-# INLINE (+~) #-}
 
 (-~) :: Num a => Setter s t a a -> a -> s -> t
 s -~ x = over s (subtract x)
+{-# INLINE (-~) #-}
 
 (*~) :: Num a => Setter s t a a -> a -> s -> t
 s *~ x = over s (* x)
+{-# INLINE (*~) #-}
 
 (/~) :: Fractional a => Setter s t a a -> a -> s -> t
 s /~ x = over s (/ x)
+{-# INLINE (/~) #-}
 
 ----
 
 (%=) :: MonadState s m => Setter s s a a -> (a -> a) -> m ()
-s %= f = do
-  state <- get
-  put $ state&s %~ f
+s %= f = modify (s %~ f)
+{-# INLINE (%=) #-}
 
 (.=) :: MonadState s m => Setter s s a a -> a -> m ()
-s .= v = s %= (const v)
+s .= v = s %= const v
+{-# INLINE (.=) #-}
 
 (+=) :: (Num a, MonadState s m) => Setter s s a a -> a -> m ()
 s += x = s %= (+ x)
+{-# INLINE (+=) #-}
 
 (-=) :: (Num a, MonadState s m) => Setter s s a a -> a -> m ()
 s -= x = s %= (subtract x)
+{-# INLINE (-=) #-}
 
 (*=) :: (Num a, MonadState s m) => Setter s s a a -> a -> m ()
 s *= x = s %= (* x)
+{-# INLINE (*=) #-}
 
 (//=) :: (Fractional a, MonadState s m) => Setter s s a a -> a -> m ()
 s //= x = s %= (/ x)
+{-# INLINE (//=) #-}
 
 ----
 
 newtype Mutator a = Mutator { runMutator :: a }
-  deriving (Show ,Read, Eq, Ord, Functor)
+  deriving (Show, Read, Eq, Ord, Functor)
 
+instance Applicative Mutator where
+  pure = Mutator
+  {-# INLINE pure #-}
+  Mutator f <*> Mutator a = Mutator (f a)
+  {-# INLINE (<*>) #-}


### PR DESCRIPTION
The absence of Applicative instance for Accessor and Mutator makes this package incompatible with traversals.

Also, added INLINE pragmas for most combinators; it'll accelerate programs considerably.